### PR TITLE
Add EZKontrol CAN protocol

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -219,6 +219,9 @@ void AP_Periph_FW::init()
 #if AP_KDECAN_ENABLED
     kdecan.init();
 #endif
+#if AP_EZKONTROL_ENABLED
+    ezkontrol.init();
+#endif
 
 #if AP_PERIPH_AIRSPEED_ENABLED
 #if (CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS) && (HAL_USE_I2C == TRUE)

--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -17,6 +17,7 @@
 #include <AP_Proximity/AP_Proximity.h>
 #include <AP_EFI/AP_EFI.h>
 #include <AP_KDECAN/AP_KDECAN.h>
+#include <AP_EZKontrol/AP_EZKontrol.h>
 #include <AP_MSP/AP_MSP.h>
 #include <AP_MSP/msp.h>
 #include <AP_TemperatureSensor/AP_TemperatureSensor.h>
@@ -334,6 +335,9 @@ public:
 
 #if AP_KDECAN_ENABLED
     AP_KDECAN kdecan;
+#endif
+#if AP_EZKONTROL_ENABLED
+    AP_EZKontrol ezkontrol;
 #endif
     
 #if AP_PERIPH_ESC_APD_ENABLED

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -581,6 +581,11 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Path: ../libraries/AP_KDECAN/AP_KDECAN.cpp
     GOBJECT(kdecan, "KDE_",   AP_KDECAN),
 #endif
+#if AP_EZKONTROL_ENABLED
+    // @Group: EZK_
+    // @Path: ../libraries/AP_EZKontrol/AP_EZKontrol.cpp
+    GOBJECT(ezkontrol, "EZK_",   AP_EZKontrol),
+#endif
 
 #if AP_PERIPH_ESC_APD_ENABLED
     GARRAY(pole_count, 0, "ESC_NUM_POLES", 22),

--- a/Tools/AP_Periph/wscript
+++ b/Tools/AP_Periph/wscript
@@ -40,6 +40,7 @@ def build(bld):
                      'AP_BattMonitor',
                      'AP_CANManager',
                      'AP_KDECAN',
+                     'AP_EZKontrol',
                      'AP_Param',
                      'StorageManager',
                      'AP_FlashStorage',

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -24,6 +24,7 @@ COMMON_VEHICLE_DEPENDENT_CAN_LIBRARIES = [
     'AP_KDECAN',
     'AP_PiccoloCAN',
     'AP_PiccoloCAN/piccolo_protocol',
+    'AP_EZKontrol',
 ]
 
 COMMON_VEHICLE_DEPENDENT_LIBRARIES = [

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1080,6 +1080,7 @@ class sitl_periph_battery_tag(sitl_periph):
 
             AP_SIM_PARAM_ENABLED = 0,
             AP_KDECAN_ENABLED = 0,
+            AP_EZKONTROL_ENABLED = 0,
             AP_TEMPERATURE_SENSOR_ENABLED = 0,
             AP_PERIPH_BATTERY_TAG_ENABLED = 1,
             AP_RTC_ENABLED = 1,

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -460,6 +460,7 @@ BUILD_OPTIONS = [
     Feature('Actuators', 'SBUS Output', 'AP_SBUSOUTPUT_ENABLED', 'Enable SBUS output on serial ports', 0, None),
     Feature('Actuators', 'FETTecOneWire', 'AP_FETTEC_ONEWIRE_ENABLED', 'Enable FETTec OneWire ESCs', 0, None),
     Feature('Actuators', 'KDECAN', 'AP_KDECAN_ENABLED', 'KDE Direct KDECAN ESC', 0, None),
+    Feature('Actuators', 'EZKontrol', 'AP_EZKONTROL_ENABLED', 'Enable EZKontrol ESC', 0, None),
     Feature('Actuators', 'HimarkServo', 'AP_DRONECAN_HIMARK_SERVO_SUPPORT', 'Enable Himark DroneCAN servos', 0, "DroneCAN"),
     Feature('Actuators', 'HobbywingESC', 'AP_DRONECAN_HOBBYWING_ESC_SUPPORT', 'Enable Hobbywing DroneCAN ESCs', 0, "DroneCAN"),
 

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -204,6 +204,7 @@ class ExtractFeatures(object):
             ('AP_FETTEC_ONEWIRE_ENABLED', r'AP_FETtecOneWire::init\b',),
             ('AP_SBUSOUTPUT_ENABLED', 'AP_SBusOut::sbus_format_frame',),
             ('AP_KDECAN_ENABLED', r'AP_KDECAN::update\b',),
+            ('AP_EZKONTROL_ENABLED', r'AP_EZKontrol::update\b',),
 
             ('AP_RPM_ENABLED', 'AP_RPM::AP_RPM',),
             ('AP_RPM_{type}_ENABLED', r'AP_RPM_(?P<type>.*)::update',),

--- a/libraries/AP_CANManager/AP_CAN.h
+++ b/libraries/AP_CANManager/AP_CAN.h
@@ -29,5 +29,6 @@ public:
         Scripting2 = 12,
         TOFSenseP = 13,
         RadarCAN = 14,  // used by NanoRadar and Hexsoon
+        EZKontrol = 15,
     };
 };

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -28,6 +28,7 @@
 #include <AP_KDECAN/AP_KDECAN.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_PiccoloCAN/AP_PiccoloCAN.h>
+#include <AP_EZKontrol/AP_EZKontrol.h>
 #include <AP_EFI/AP_EFI_NWPMU.h>
 #include <GCS_MAVLink/GCS.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
@@ -225,6 +226,14 @@ void AP_CANManager::init()
             AP_Param::load_object_from_eeprom((AP_PiccoloCAN*)_drivers[drv_num], AP_PiccoloCAN::var_info);
             break;
 #endif
+        case AP_CAN::Protocol::EZKontrol:
+            _drivers[drv_num] = NEW_NOTHROW AP_EZKontrol;
+            if (_drivers[drv_num] == nullptr) {
+                AP_BoardConfig::allocation_error("EZKontrol %d", drv_num + 1);
+                continue;
+            }
+            AP_Param::load_object_from_eeprom((AP_EZKontrol*)_drivers[drv_num], AP_EZKontrol::var_info);
+            break;
         default:
             continue;
         }

--- a/libraries/AP_CANManager/AP_CANManager_CANDriver_Params.cpp
+++ b/libraries/AP_CANManager/AP_CANManager_CANDriver_Params.cpp
@@ -20,6 +20,7 @@
 
 #include <AP_DroneCAN/AP_DroneCAN.h>
 #include <AP_PiccoloCAN/AP_PiccoloCAN.h>
+#include <AP_EZKontrol/AP_EZKontrol.h>
 
 // table of user settable CAN bus parameters
 const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
@@ -28,7 +29,7 @@ const AP_Param::GroupInfo AP_CANManager::CANDriver_Params::var_info[] = {
     // @DisplayName: Enable use of specific protocol over virtual driver
     // @Description: Enabling this option starts selected protocol that will use this virtual driver
     // @SortValues: AlphabeticalZeroAtTop
-    // @Values: 0:Disabled,1:DroneCAN,4:PiccoloCAN,6:EFI_NWPMU,7:USD1,8:KDECAN,10:Scripting,11:Benewake,12:Scripting2,13:TOFSenseP,14:RadarCAN (NanoRadar/Hexsoon)
+    // @Values: 0:Disabled,1:DroneCAN,4:PiccoloCAN,6:EFI_NWPMU,7:USD1,8:KDECAN,10:Scripting,11:Benewake,12:Scripting2,13:TOFSenseP,14:RadarCAN (NanoRadar/Hexsoon),15:EZKontrol
     // @User: Advanced
     // @RebootRequired: True
     AP_GROUPINFO("PROTOCOL", 1, AP_CANManager::CANDriver_Params, _driver_type, float(AP_CAN::Protocol::DroneCAN)),

--- a/libraries/AP_EZKontrol/AP_EZKontrol.cpp
+++ b/libraries/AP_EZKontrol/AP_EZKontrol.cpp
@@ -1,0 +1,138 @@
+#include "AP_EZKontrol.h"
+
+#if AP_EZKONTROL_ENABLED
+
+#include <GCS_MAVLink/GCS.h>
+
+AP_EZKontrol *AP_EZKontrol::_singleton;
+
+const AP_Param::GroupInfo AP_EZKontrol::var_info[] = {
+    // @Param: ESC1_ADDR
+    // @DisplayName: Address for ESC1
+    // @Range: 0 255
+    // @User: Advanced
+    AP_GROUPINFO("ESC1_ADDR", 1, AP_EZKontrol, esc1_addr, 2),
+
+    // @Param: ESC2_ADDR
+    // @DisplayName: Address for ESC2
+    // @Range: 0 255
+    // @User: Advanced
+    AP_GROUPINFO("ESC2_ADDR", 2, AP_EZKontrol, esc2_addr, 3),
+
+    // @Param: VCU_ADDR
+    // @DisplayName: Vehicle controller address
+    // @Range: 0 255
+    // @User: Advanced
+    AP_GROUPINFO("VCU_ADDR", 3, AP_EZKontrol, vcu_addr, 239),
+
+    // @Param: TARGET_I
+    // @DisplayName: Target phase current (0.1A)
+    // @Range: -32000 32000
+    // @User: Advanced
+    AP_GROUPINFO("TARGET_I", 4, AP_EZKontrol, target_phase_current, 0),
+
+    // @Param: MODE
+    // @DisplayName: Control mode
+    // @Values: 0:Torque,1:Speed
+    // @User: Advanced
+    AP_GROUPINFO("MODE", 5, AP_EZKontrol, control_mode, 0),
+
+    AP_GROUPEND
+};
+
+AP_EZKontrol::AP_EZKontrol()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+    if (_singleton == nullptr) {
+        _singleton = this;
+    }
+    _driver = nullptr;
+}
+
+void AP_EZKontrol::init()
+{
+    if (_driver != nullptr) {
+        return;
+    }
+    for (uint8_t i=0; i<HAL_NUM_CAN_IFACES; i++) {
+        if (CANSensor::get_driver_type(i) == AP_CAN::Protocol::EZKontrol) {
+            _driver = NEW_NOTHROW AP_EZKontrol_Driver();
+            return;
+        }
+    }
+}
+
+void AP_EZKontrol::update()
+{
+    if (_driver != nullptr) {
+        _driver->update();
+    }
+}
+
+AP_EZKontrol_Driver::AP_EZKontrol_Driver() : CANSensor("EZKontrol")
+{
+    register_driver(AP_CAN::Protocol::EZKontrol);
+    _handshake_done = false;
+    _live_counter = 0;
+    _last_ms = 0;
+}
+
+void AP_EZKontrol_Driver::update()
+{
+    const uint32_t now = AP_HAL::millis();
+    if (!_handshake_done) {
+        if (now - _last_ms >= 50) {
+            send_handshake();
+            _last_ms = now;
+        }
+    } else {
+        if (now - _last_ms >= 50) {
+            send_command();
+            _last_ms = now;
+        }
+    }
+}
+
+void AP_EZKontrol_Driver::send_handshake()
+{
+    uint8_t buf[8];
+    memset(buf, 0x55, sizeof(buf));
+    AP_HAL::CANFrame frame(0x1801D0EF | AP_HAL::CANFrame::FlagEFF, buf, 8, false);
+    write_frame(frame, 1000);
+}
+
+void AP_EZKontrol_Driver::send_command()
+{
+    const AP_EZKontrol *inst = AP_EZKontrol::get_singleton();
+    if (inst == nullptr) {
+        return;
+    }
+    uint8_t buf[8] = {};
+    int16_t current = inst->target_phase_current;
+    buf[0] = uint8_t(current);
+    buf[1] = uint8_t(current >> 8);
+    buf[4] = inst->control_mode;
+    buf[7] = _live_counter++;
+    AP_HAL::CANFrame frame(0x0C01EFD0 | AP_HAL::CANFrame::FlagEFF, buf, 8, false);
+    write_frame(frame, 1000);
+}
+
+void AP_EZKontrol_Driver::handle_frame(AP_HAL::CANFrame &frame)
+{
+    if (!frame.isExtended()) {
+        return;
+    }
+    if (frame.id == 0x0C01EFD0 && frame.dlc == 8 && frame.data[0] == 0xAA) {
+        _handshake_done = true;
+    }
+    // telemetry frames could be handled here
+}
+
+namespace AP {
+AP_EZKontrol *ezkontrol()
+{
+    return AP_EZKontrol::get_singleton();
+}
+}
+
+#endif // AP_EZKONTROL_ENABLED

--- a/libraries/AP_EZKontrol/AP_EZKontrol.h
+++ b/libraries/AP_EZKontrol/AP_EZKontrol.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "AP_EZKontrol_config.h"
+
+#if AP_EZKONTROL_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_CANManager/AP_CANSensor.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
+
+class AP_EZKontrol_Driver : public CANSensor, public AP_ESC_Telem_Backend {
+public:
+    AP_EZKontrol_Driver();
+    void update();
+
+private:
+    void handle_frame(AP_HAL::CANFrame &frame) override;
+    void send_handshake();
+    void send_command();
+
+    bool _handshake_done;
+    uint8_t _live_counter;
+    uint32_t _last_ms;
+};
+
+class AP_EZKontrol {
+public:
+    AP_EZKontrol();
+    void init();
+    void update();
+
+    static AP_EZKontrol *get_singleton() { return _singleton; }
+    static const struct AP_Param::GroupInfo var_info[];
+
+    AP_Int8 esc1_addr;
+    AP_Int8 esc2_addr;
+    AP_Int8 vcu_addr;
+    AP_Int16 target_phase_current;
+    AP_Int8 control_mode;
+
+private:
+    static AP_EZKontrol *_singleton;
+    AP_EZKontrol_Driver *_driver;
+};
+
+namespace AP {
+    AP_EZKontrol *ezkontrol();
+}
+
+#endif // AP_EZKONTROL_ENABLED

--- a/libraries/AP_EZKontrol/AP_EZKontrol_config.h
+++ b/libraries/AP_EZKontrol/AP_EZKontrol_config.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <AP_HAL/AP_HAL_Boards.h>
+
+#ifndef AP_EZKONTROL_ENABLED
+#define AP_EZKONTROL_ENABLED (HAL_MAX_CAN_PROTOCOL_DRIVERS && HAL_PROGRAM_SIZE_LIMIT_KB > 1024)
+#endif


### PR DESCRIPTION
## Summary
- implement a new CAN protocol `EZKontrol`
- expose `EZKontrol` in CAN manager driver selection
- add EZKontrol driver skeleton with handshake and command support
- enable parameters for addresses, mode, and phase current
- integrate EZKontrol with AP_Periph build system

## Testing
- `./waf configure --board CUAV-X7` *(fails: Could not find the program ['arm-none-eabi-ar'])*

------
https://chatgpt.com/codex/tasks/task_e_688b1db92bd0832e8c1636f24230a9bc