### PR TITLE
Implement EZKontrol CAN ESC driver

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -1276,6 +1276,7 @@ bool AP_Arming::can_checks(bool report)
                 case AP_CAN::Protocol::TOFSenseP:
                 case AP_CAN::Protocol::RadarCAN:
                 case AP_CAN::Protocol::Benewake:
+                case AP_CAN::Protocol::EZKontrol:
                 {
                     for (uint8_t j = i; j; j--) {
                         if (AP::can().get_driver_type(i) == AP::can().get_driver_type(j-1)) {

--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -28,6 +28,7 @@
 #include <AP_KDECAN/AP_KDECAN.h>
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_PiccoloCAN/AP_PiccoloCAN.h>
+#include <AP_EZKontrol/AP_EZKontrol.h>
 #include <AP_EFI/AP_EFI_NWPMU.h>
 #include <GCS_MAVLink/GCS.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
@@ -225,6 +226,14 @@ void AP_CANManager::init()
             AP_Param::load_object_from_eeprom((AP_PiccoloCAN*)_drivers[drv_num], AP_PiccoloCAN::var_info);
             break;
 #endif
+        case AP_CAN::Protocol::EZKontrol:
+            _drivers[drv_num] = _drv_param[drv_num]._ezkontrol = NEW_NOTHROW AP_EZKontrol_Driver();
+            if (_drivers[drv_num] == nullptr) {
+                AP_BoardConfig::allocation_error("EZKontrol %d", drv_num + 1);
+                continue;
+            }
+            AP_Param::load_object_from_eeprom((AP_EZKontrol*)_drivers[drv_num], AP_EZKontrol::var_info);
+            break;
         default:
             continue;
         }

--- a/libraries/AP_CANManager/AP_CANManager.h
+++ b/libraries/AP_CANManager/AP_CANManager.h
@@ -172,6 +172,7 @@ private:
         AP_Int8 _driver_type_11bit;
         AP_CANDriver* _uavcan;
         AP_CANDriver* _piccolocan;
+        AP_CANDriver* _ezkontrol;
     };
 
     CANIface_Params _interfaces[HAL_NUM_CAN_IFACES];

--- a/libraries/AP_EZKontrol/AP_EZKontrol.cpp
+++ b/libraries/AP_EZKontrol/AP_EZKontrol.cpp
@@ -3,6 +3,7 @@
 #if AP_EZKONTROL_ENABLED
 #include <AP_HAL/utility/sparse-endian.h>
 #include <GCS_MAVLink/GCS.h>
+#include <SRV_Channel/SRV_Channel.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -42,53 +43,86 @@ const AP_Param::GroupInfo AP_EZKontrol::var_info[] = {
     AP_GROUPEND
 };
 
-// CAN IDs
-static const uint32_t ID_VCU_TX = 0x0C01EFD0;
-static const uint32_t ID_MCU_TX1 = 0x1801D0EF;
-static const uint32_t ID_MCU_TX2 = 0x1802D0EF;
+static inline uint32_t make_vcu_tx_id(uint8_t esc_addr, uint8_t vcu_addr)
+{
+    return (0x0CU << 24) | (0x01U << 16) | (uint32_t(esc_addr) << 8) | vcu_addr;
+}
+
+static inline uint32_t make_mcu_tx1_id(uint8_t esc_addr, uint8_t vcu_addr)
+{
+    return (0x18U << 24) | (0x01U << 16) | (uint32_t(vcu_addr) << 8) | esc_addr;
+}
+
+static inline uint32_t make_mcu_tx2_id(uint8_t esc_addr, uint8_t vcu_addr)
+{
+    return (0x18U << 24) | (0x02U << 16) | (uint32_t(vcu_addr) << 8) | esc_addr;
+}
 
 AP_EZKontrol_Driver::AP_EZKontrol_Driver() : CANSensor("EZKontrol")
 {
     register_driver(AP_CAN::Protocol::EZKontrol);
 }
 
-void AP_EZKontrol_Driver::send_handshake()
+void AP_EZKontrol_Driver::set_addresses(uint8_t esc1, uint8_t esc2, uint8_t vcu)
 {
+    _esc_addr[0] = esc1;
+    _esc_addr[1] = esc2;
+    _vcu_addr = vcu;
+}
+
+void AP_EZKontrol_Driver::set_target(uint8_t idx, int16_t current, int16_t speed)
+{
+    if (idx < 2) {
+        _target_current[idx] = current;
+        _target_speed[idx] = speed;
+    }
+}
+
+void AP_EZKontrol_Driver::send_handshake(uint8_t idx)
+{
+    if (idx >= 2) {
+        return;
+    }
     uint8_t buf[8];
     memset(buf, 0xAA, sizeof(buf));
-    AP_HAL::CANFrame frame(ID_VCU_TX | AP_HAL::CANFrame::FlagEFF, buf, sizeof(buf), false);
+    const uint32_t id = make_vcu_tx_id(_esc_addr[idx], _vcu_addr);
+    AP_HAL::CANFrame frame(id | AP_HAL::CANFrame::FlagEFF, buf, sizeof(buf), false);
     write_frame(frame, 1000);
 }
 
-void AP_EZKontrol_Driver::send_command()
+void AP_EZKontrol_Driver::send_command(uint8_t idx)
 {
+    if (idx >= 2) {
+        return;
+    }
     uint8_t buf[8];
-    buf[0] = _target_current & 0xFF;
-    buf[1] = (_target_current >> 8) & 0xFF;
-    buf[2] = _target_speed & 0xFF;
-    buf[3] = (_target_speed >> 8) & 0xFF;
+    buf[0] = _target_current[idx] & 0xFF;
+    buf[1] = (_target_current[idx] >> 8) & 0xFF;
+    buf[2] = _target_speed[idx] & 0xFF;
+    buf[3] = (_target_speed[idx] >> 8) & 0xFF;
     buf[4] = _control_mode;
     buf[5] = 0;
     buf[6] = 0;
-    buf[7] = _life++;
+    buf[7] = _life[idx]++;
 
-    AP_HAL::CANFrame frame(ID_VCU_TX | AP_HAL::CANFrame::FlagEFF, buf, sizeof(buf), false);
+    const uint32_t id = make_vcu_tx_id(_esc_addr[idx], _vcu_addr);
+    AP_HAL::CANFrame frame(id | AP_HAL::CANFrame::FlagEFF, buf, sizeof(buf), false);
     write_frame(frame, 1000);
 }
 
 void AP_EZKontrol_Driver::update()
 {
     const uint32_t now = AP_HAL::millis();
-    if (!_handshake_done) {
-        if (now - _last_tx_ms >= 50) {
-            send_handshake();
-            _last_tx_ms = now;
+    for (uint8_t i = 0; i < 2; i++) {
+        if (!_handshake_done[i]) {
+            if (now - _last_tx_ms >= 50) {
+                send_handshake(i);
+            }
+        } else if (now - _last_tx_ms >= 50) {
+            send_command(i);
         }
-        return;
     }
-
     if (now - _last_tx_ms >= 50) {
-        send_command();
         _last_tx_ms = now;
     }
 }
@@ -101,43 +135,47 @@ void AP_EZKontrol_Driver::handle_frame(AP_HAL::CANFrame &frame)
 
     const uint32_t id = frame.id & AP_HAL::CANFrame::MaskExtID;
 
-    if (id == ID_MCU_TX1) {
-        if (frame.dlc == 8) {
-            bool all55 = true;
-            for (uint8_t i=0;i<8;i++) {
-                if (frame.data[i] != 0x55) { all55 = false; break; }
-            }
-            if (all55 && !_handshake_done) {
-                _handshake_done = true;
-                return;
-            }
+    for (uint8_t idx = 0; idx < 2; idx++) {
+        if (id == make_mcu_tx1_id(_esc_addr[idx], _vcu_addr)) {
+            if (frame.dlc == 8) {
+                bool all55 = true;
+                for (uint8_t i=0;i<8;i++) {
+                    if (frame.data[i] != 0x55) { all55 = false; break; }
+                }
+                if (all55 && !_handshake_done[idx]) {
+                    _handshake_done[idx] = true;
+                    return;
+                }
 
 #if HAL_WITH_ESC_TELEM
-            int16_t bus_v = le16toh_ptr(&frame.data[0]);
-            int16_t bus_c = le16toh_ptr(&frame.data[2]);
-            int16_t phase_c = le16toh_ptr(&frame.data[4]);
-            int16_t speed = le16toh_ptr(&frame.data[6]);
+                int16_t bus_v = le16toh_ptr(&frame.data[0]);
+                int16_t bus_c = le16toh_ptr(&frame.data[2]);
+                (void)le16toh_ptr(&frame.data[4]);
+                int16_t speed = le16toh_ptr(&frame.data[6]);
 
+                TelemetryData t{};
+                t.voltage = float(bus_v) * 0.1f;
+                t.current = float(bus_c) * 0.1f;
+                update_rpm(idx, speed, 0);
+                update_telem_data(idx, t,
+                                  TelemetryType::CURRENT |
+                                  TelemetryType::VOLTAGE);
+#endif
+            }
+            return;
+        } else if (id == make_mcu_tx2_id(_esc_addr[idx], _vcu_addr) && frame.dlc == 8) {
+#if HAL_WITH_ESC_TELEM
+            int8_t ctrl_temp = int8_t(frame.data[0]);
+            int8_t motor_temp = int8_t(frame.data[1]);
             TelemetryData t{};
-            t.voltage = float(bus_v) * 0.1f;
-            t.current = float(bus_c) * 0.1f;
-            update_rpm(0, speed, 0);
-            update_telem_data(0, t,
-                              TelemetryType::CURRENT |
-                              TelemetryType::VOLTAGE);
+            t.temperature_cdeg = motor_temp * 100;
+            t.motor_temp_cdeg = ctrl_temp * 100;
+            update_telem_data(idx, t,
+                              TelemetryType::TEMPERATURE |
+                              TelemetryType::MOTOR_TEMPERATURE);
 #endif
+            return;
         }
-    } else if (id == ID_MCU_TX2 && frame.dlc == 8) {
-#if HAL_WITH_ESC_TELEM
-        int8_t ctrl_temp = int8_t(frame.data[0]);
-        int8_t motor_temp = int8_t(frame.data[1]);
-        TelemetryData t{};
-        t.temperature_cdeg = motor_temp * 100;
-        t.motor_temp_cdeg = ctrl_temp * 100;
-        update_telem_data(0, t,
-                          TelemetryType::TEMPERATURE |
-                          TelemetryType::MOTOR_TEMPERATURE);
-#endif
     }
 }
 
@@ -161,6 +199,9 @@ void AP_EZKontrol::init()
     for (uint8_t i = 0; i < HAL_NUM_CAN_IFACES; i++) {
         if (CANSensor::get_driver_type(i) == AP_CAN::Protocol::EZKontrol) {
             _driver = NEW_NOTHROW AP_EZKontrol_Driver();
+            if (_driver != nullptr) {
+                _driver->set_addresses(esc1_addr.get(), esc2_addr.get(), vcu_addr.get());
+            }
             return;
         }
     }
@@ -168,9 +209,24 @@ void AP_EZKontrol::init()
 
 void AP_EZKontrol::update()
 {
-    if (_driver != nullptr) {
-        _driver->update();
+    if (_driver == nullptr) {
+        return;
     }
+
+    float left = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleLeft);
+    float right = SRV_Channels::get_output_scaled(SRV_Channel::k_throttleRight);
+
+    if (cmd_mode.get() == 0) {
+        int16_t max_cur = target_phase_cur.get();
+        _driver->set_target(0, int16_t(constrain_float(left, -1.0f, 1.0f) * max_cur), 0);
+        _driver->set_target(1, int16_t(constrain_float(right, -1.0f, 1.0f) * max_cur), 0);
+    } else {
+        int16_t cur = target_phase_cur.get();
+        _driver->set_target(0, cur, int16_t(constrain_float(left, -1.0f, 1.0f) * 32000.0f));
+        _driver->set_target(1, cur, int16_t(constrain_float(right, -1.0f, 1.0f) * 32000.0f));
+    }
+    _driver->set_control_mode(cmd_mode.get());
+    _driver->update();
 }
 
 AP_EZKontrol *AP_EZKontrol::_singleton;

--- a/libraries/AP_EZKontrol/AP_EZKontrol.h
+++ b/libraries/AP_EZKontrol/AP_EZKontrol.h
@@ -22,23 +22,27 @@ public:
 
     void update();
 
-    void set_target_current(int16_t c) { _target_current = c; }
-    void set_target_speed(int16_t s) { _target_speed = s; }
+    void set_addresses(uint8_t esc1, uint8_t esc2, uint8_t vcu);
+
+    void set_target(uint8_t idx, int16_t current, int16_t speed);
+
     void set_control_mode(uint8_t m) { _control_mode = m; }
 
 private:
     void handle_frame(AP_HAL::CANFrame &frame) override;
 
-    void send_handshake();
-    void send_command();
+    void send_handshake(uint8_t idx);
+    void send_command(uint8_t idx);
 
-    bool _handshake_done = false;
-    uint8_t _life = 0;
-    uint32_t _last_tx_ms = 0;
+    uint8_t _esc_addr[2]{};
+    uint8_t _vcu_addr{0};
+    bool _handshake_done[2]{};
+    uint8_t _life[2]{};
+    uint32_t _last_tx_ms{0};
 
-    int16_t _target_current = 0;
-    int16_t _target_speed = 0;
-    uint8_t _control_mode = 0;
+    int16_t _target_current[2]{};
+    int16_t _target_speed[2]{};
+    uint8_t _control_mode{0};
 };
 
 class AP_EZKontrol {


### PR DESCRIPTION
## Summary
- add EZKontrol driver structures and parameters
- implement handshake, command, and telemetry for two ESCs
- hook driver into CAN manager and arming checks
- build rover for CUAV X7 to verify build

## Testing
- `./waf configure --board CUAV-X7`
- `./waf rover`

------
https://chatgpt.com/codex/tasks/task_e_688b701b5d10832e81c6aa51d9e6f9e8