### PR TITLE
Ardupilot-4.6_me1

### DIFF
--- a/libraries/AP_DroneCAN/AP_Canard_iface.h
+++ b/libraries/AP_DroneCAN/AP_Canard_iface.h
@@ -15,7 +15,9 @@ public:
     CanardInterface(const CanardInterface&) = delete;
     CanardInterface& operator=(const CanardInterface&) = delete;
 
-    CanardInterface(uint8_t driver_index);
+    CanardInterface(AP_DroneCAN *parent, uint8_t driver_index);
+
+    void set_parent(AP_DroneCAN *parent) { _parent = parent; }
 
     void init(void* mem_arena, size_t mem_arena_size, uint8_t node_id);
 
@@ -81,5 +83,7 @@ private:
 
     // auxillary 11 bit CANSensor
     CANSensor *aux_11bit_driver;
+
+    AP_DroneCAN *_parent;
 };
 #endif // HAL_ENABLE_DRONECAN_DRIVERS

--- a/libraries/AP_DroneCAN/AP_DroneCAN.h
+++ b/libraries/AP_DroneCAN/AP_DroneCAN.h
@@ -108,6 +108,10 @@ public:
     FUNCTOR_TYPEDEF(ParamSaveCb, void, AP_DroneCAN*,  const uint8_t, bool);
 
     void send_node_status();
+    void process_raw_frame(const AP_HAL::CANFrame &frame);
+
+    enum class HBState : uint8_t { STANDBY, HANDSHAKE_DONE };
+    void update_handshake();
 
     ///// SRV output /////
     void SRV_push_servos(void);
@@ -237,6 +241,16 @@ private:
     AP_Int16 _notify_state_hz;
     AP_Int16 _pool_size;
     AP_Int32 _esc_rv;
+
+    AP_Int8 _vcu_id;
+    AP_Int8 _mcu_id;
+    AP_Int16 _ez_hz;
+    AP_Int8 _ez_esc;
+    AP_Int16 _ez_tpc;
+
+    uint8_t _hb_seq{0};
+    HBState _hb_state{HBState::STANDBY};
+    uint32_t _hb_last_rx_ms{0};
 
     uint32_t *mem_pool;
 

--- a/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/DroneCAN_sniffer.cpp
+++ b/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/DroneCAN_sniffer.cpp
@@ -132,7 +132,7 @@ void DroneCAN_sniffer::init(void)
         debug_dronecan("Can not initialised\n");
         return;
     }
-    _uavcan_iface_mgr = NEW_NOTHROW CanardInterface{driver_index};
+    _uavcan_iface_mgr = NEW_NOTHROW CanardInterface{nullptr, driver_index};
 
     if (_uavcan_iface_mgr == nullptr) {
         return;


### PR DESCRIPTION
## Summary
- allow DroneCAN heartbeat payload to be customised via new EZ_TPC parameter
- include vehicle arm state and incrementing life byte in heartbeat frame
- start heartbeat only after handshake frame 0x55 is received on ID 0x18 0x01 VCU_ID MCU_ID

## Testing
- `pre-commit run --files libraries/AP_DroneCAN/AP_Canard_iface.h libraries/AP_DroneCAN/AP_Canard_iface.cpp libraries/AP_DroneCAN/AP_DroneCAN.h libraries/AP_DroneCAN/AP_DroneCAN.cpp libraries/AP_DroneCAN/examples/DroneCAN_sniffer/DroneCAN_sniffer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_688b81d87714832eb281b58c8e23834c